### PR TITLE
Letter spacing in the headers on the index and language pages were off.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -811,6 +811,7 @@ a {
 				color: #fff;
 				font-weight: 400;
 				border: 0;
+				letter-spacing: 0.1em;
 			}
 
 		#header nav {


### PR DESCRIPTION
The fixed letter spacing of the header, tl;dr{Code}. index.html was normal, but inside specific languages, the kerning were too close. This would explicitly make it consistent
