### PR TITLE
Some slight modifications to get Prism highlighting to work

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,6 @@
   <script src="/js/skel.min.js"></script>
   <script src="/js/skel-layers.min.js"></script>
   <script src="/js/init.js"></script>
-  <script src="/js/prism.js"></script>
   <link rel="stylesheet" href="/fonts/font-mfizz.css">
   <link rel="stylesheet" href="/css/prism.css">
   <link rel="SHORTCUT ICON" href="/favicon.ico" />

--- a/_languages/c-plusplus.markdown
+++ b/_languages/c-plusplus.markdown
@@ -4,6 +4,7 @@ icon: icon-cplusplus
 
 Language: C++
 Language_Description: Object oriented programming language based on 'C.'
+prism_name: cpp
 
 Data_Types:
 - Type: int
@@ -35,12 +36,31 @@ Structures:
 
 - Type: else
   Description: Follows an if block and will be executed if the if block isn't.
-  Syntax: else {code}
+  Syntax: if(false){...} else {code}
+  Example: |
+    int i = 0;
+    if(i == 1){
+      ...
+    }
+    else{
+      //code
+    }
 
 - Type: else if
   Description: Follows an if block and will be executed if the previous if block wasn't executed and the new parameters are met.
-  Syntax: else if (statement) {code}
-  Example: else if (x==5) {code}
+  Syntax: |
+    if(boolean_logic){
+      ...
+    }else if (boolean_logic) {
+      //code
+    }
+  Example: |
+    int i = 5;
+    if(i < 0){
+      ...
+    }else if (i > 0) {
+      //code
+    }
   Example_Description: Executes when previous if block doesn't and only if x equals 5.
 
 - Type: while

--- a/_languages/c-sharp.markdown
+++ b/_languages/c-sharp.markdown
@@ -4,6 +4,8 @@ icon: icon-csharp
 
 Language: 'C#'
 Language_Description: An object oriented hybrid of C and C++ designed for Windows development.
+prism_name: csharp
+
 
 Data_Types:
 - Type: int

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,6 @@
     {{ content }}
 
     {% include footer.html %}
-
+    <script src="/js/prism.js"></script>
   </body>
 </html>

--- a/_layouts/language.html
+++ b/_layouts/language.html
@@ -1,7 +1,10 @@
 ---
 layout: default
 ---
-
+{% assign prism_name =  page.Language | downcase %}
+{% if page.prism_name %}
+{% assign prism_name =  page.prism_name %}
+{% endif %}
 <!-- Main -->
   <div id="main">
     <div class="container">
@@ -34,7 +37,7 @@ layout: default
             <h2><a onclick="toggle_visibility('{{ Data_Type.Type }}');">{{ Data_Type.Type }} <i class="icon fa-angle-down"></i></a></h2>
             <div style="display: none;" id='{{ Data_Type.Type }}'>
               {{ Data_Type.Description }}
-              <pre><code class="language-{{ page.Language }}">{{ Data_Type.Syntax }}</code></pre>
+              <pre><code class="language-{{ prism_name }}">{{ Data_Type.Syntax }}</code></pre>
             </div>
           {% endfor %}
           </div>
@@ -46,9 +49,9 @@ layout: default
             <div style="display: none;" id='{{ Structure.Type }}'>
               {{ Structure.Description }}</p>
               Syntax
-              <pre><code class="language-{{ page.Language }}">{{ Structure.Syntax }}</code></pre>
+              <pre><code class="language-{{ prism_name }}">{{ Structure.Syntax }}</code></pre>
               Example
-              <pre><code class="language-{{ page.Language }}">{{ Structure.Example }}</code></pre>
+              <pre><code class="language-{{ prism_name }}">{{ Structure.Example }}</code></pre>
               {{ Structure.Example_Description }}
             </div>
           {% endfor %}
@@ -60,8 +63,8 @@ layout: default
             <h2><a onclick="toggle_visibility('{{ User_Interface.Type }}');">{{ User_Interface.Type }} <i class="icon fa-angle-down"></i></a></h2>
             <div style="display: none;" id='{{ User_Interface.Type }}'>
               {{ User_Interface.Description }}
-              <pre><code class="language-{{ page.Language }}">{{ User_Interface.Syntax }}</code></pre>
-              <pre><code class="language-{{ page.Language }}">{{ User_Interface.Example }}</code></pre>
+              <pre><code class="language-{{ prism_name }}">{{ User_Interface.Syntax }}</code></pre>
+              <pre><code class="language-{{ prism_name }}">{{ User_Interface.Example }}</code></pre>
               {{ User_Interface.Example_Description }}
             </div>
           {% endfor %}
@@ -74,7 +77,7 @@ layout: default
             {% for Comment in page.Comments %}
             <h2><a onclick="toggle_visibility('{{ Comment.Type }}');">{{ Comment.Type }} <i class="icon fa-angle-down"></i></a></h2>
             <div style="display: none;" id='{{ Comment.Type }}'>
-              <pre><code class="language-{{ page.Language }}">{{ Comment.Syntax }}</code></pre>
+              <pre><code class="language-{{ prism_name }}">{{ Comment.Syntax }}</code></pre>
             </div>
             {% endfor %}
           </div>
@@ -83,7 +86,7 @@ layout: default
             <h1>Hello World</h1>
             <h2><a onclick="toggle_visibility('HelloWorld');">Example <i class="icon fa-angle-down"></i></a></h2>
             <div style="display: none;" id='HelloWorld'>
-              <pre><code class="language-{{ page.Language }}">{{ page.Hello_World | escape }}</code></pre>
+              <pre><code class="language-{{ prism_name }}">{{ page.Hello_World | escape }}</code></pre>
             </div>
           </div>
         </div>

--- a/js/prism.js
+++ b/js/prism.js
@@ -23,6 +23,29 @@ Prism.languages.rip={comment:/#[^\r\n]*(\r?\n|$)/g,keyword:/(?:=>|->)|\b(?:class
 Prism.languages.gherkin={comment:{pattern:/(^|[^\\])(\/\*[\w\W]*?\*\/|((#)|(\/\/)).*?(\r?\n|$))/g,lookbehind:!0},string:/("|')(\\?.)*?\1/g,atrule:/\b(And|Given|When|Then|In order to|As an|I want to|As a)\b/g,keyword:/\b(Scenario Outline|Scenario|Feature|Background|Story)\b/g};;
 Prism.languages.csharp=Prism.languages.extend("clike",{keyword:/\b(abstract|as|base|bool|break|byte|case|catch|char|checked|class|const|continue|decimal|default|delegate|do|double|else|enum|event|explicit|extern|false|finally|fixed|float|for|foreach|goto|if|implicit|in|int|interface|internal|is|lock|long|namespace|new|null|object|operator|out|override|params|private|protected|public|readonly|ref|return|sbyte|sealed|short|sizeof|stackalloc|static|string|struct|switch|this|throw|true|try|typeof|uint|ulong|unchecked|unsafe|ushort|using|virtual|void|volatile|while|add|alias|ascending|async|await|descending|dynamic|from|get|global|group|into|join|let|orderby|partial|remove|select|set|value|var|where|yield)\b/g,string:/@?("|')(\\?.)*?\1/g,preprocessor:/^\s*#.*/gm,number:/\b-?(0x)?\d*\.?\d+\b/g});;
 Prism.languages.go=Prism.languages.extend("clike",{keyword:/\b(break|case|chan|const|continue|default|defer|else|fallthrough|for|func|go(to)?|if|import|interface|map|package|range|return|select|struct|switch|type|var)\b/g,builtin:/\b(bool|byte|complex(64|128)|error|float(32|64)|rune|string|u?int(8|16|32|64|)|uintptr|append|cap|close|complex|copy|delete|imag|len|make|new|panic|print(ln)?|real|recover)\b/g,"boolean":/\b(_|iota|nil|true|false)\b/g,operator:/([(){}\[\]]|[*\/%^!]=?|\+[=+]?|-[>=-]?|\|[=|]?|>[=>]?|<(<|[=-])?|==?|&(&|=|^=?)?|\.(\.\.)?|[,;]|:=?)/g,number:/\b(-?(0x[a-f\d]+|(\d+\.?\d*|\.\d+)(e[-+]?\d+)?)i?)\b/gi,string:/("|'|`)(\\?.|\r|\n)*?\1/g}),delete Prism.languages.go["class-name"];;
+
+/**
+ * powershell is from github.com/pezhore/prism-powershell
+ */
+Prism.languages.powershell = {
+        // This comment regex is ugly because prism.js replaces "<" with "&lt;" behind the scenes for some reason
+        'comment': /(\&lt\;#[\w\W]*?#>)|(\#.*)/g,
+
+        'string': /(\@\"[\w\W]*?\"\@)|((\'|\")[\w\W]*?(\'|\"))/g,
+        'keyword': /\b(switch|if|else|while|do|for|return|function|new|try|throw|catch|finally|break|exit|begin|process|end)(?![-\S])?\b/ig,
+        'boolean': /(\$true|\$false)/g,
+
+        // This is for PowerShell Actions, leveraging the theme's pre-defined color scheme for attr-value
+        'attr-value': /(add|get|read|test|start|new|set|write|output|where)-\S*/ig,
+
+        // This is for PowerShell Variables, leveraging the theme's pre-defined color scheme for symbol
+        'symbol': /(?!(\$true|\$false))(\$[a-z|A-Z|0-9|_|-]*)\b/g,
+
+        'number': /\b-?(0x[\dA-Fa-f]+|\d*\.?\d+([Ee]-?\d+)?)\b/g,
+        'operator': /[-+]{1,2}|!|&lt;=?|>=?|={1,3}|(&amp;){1,2}|\|?\||\?|\*|\/|\~|\^|\%|-or|-and|-lt|-le|-gt|-ge|-match|-like/g,
+        'ignore': /&(lt|gt|amp);/gi,
+        'punctuation': /[{}[\];(),.:]/g
+};
 /**
  * Original by Jan T. Sott (http://github.com/idleberg)
  *


### PR DESCRIPTION
Slight modifications to get Prism highlighting to work. 
- Quick changes were lowercasing the language name. `language-C` to `language-c`
- The little more involved modification required dynamically adjusting for special names, like `language-C++` to `language-cpp`
- Added [Powershell](https://github.com/pezhore/prism-powershell) support 
