### PR TITLE
Improved styling of base64 tool page

### DIFF
--- a/coding_tools/base64-ascii.html
+++ b/coding_tools/base64-ascii.html
@@ -7,7 +7,7 @@ layout: default
       <div id="content" class="12u">
         <article>
           <header>
-            <h2>Base64 &lt;-&gt; ASCII </h2>
+            <h2>Base64 &larr;&rarr; ASCII </h2>
           </header>
       </div>
     </div>
@@ -15,12 +15,12 @@ layout: default
     <div class="row">
       <div class="6u">
         <h1>Base64</h1>
-        <textarea type="text" id="base64"></textarea>
+        <textarea type="text" id="base64" class="text-base64-ascii"></textarea>
         <br><button type="button" class="button" id="base64toascii" onclick="base64toascii()">Convert Base64 to ASCII</button>
       </div>
       <div class="6u">
         <h1>ASCII</h1>
-        <textarea type="text" id="ascii"></textarea>
+        <textarea type="text" id="ascii" class="text-base64-ascii"></textarea>
         <br><button type="button" class="button" id="asciitobase64" onclick="asciitobase64()">Convert ASCII to Base64</button>
       </div>
     </div>

--- a/css/style.css
+++ b/css/style.css
@@ -1621,3 +1621,19 @@ ul.featured li {
     border-color: #2a2a2a !important;
     color: rgba(255,255,255,1) !important;
 }
+
+/*********************************************************************************/
+/* base64 <-> ascii textarea                                                     */
+/*********************************************************************************/
+
+textarea.text-base64-ascii {
+    -webkit-appearance: none;
+    display: block;
+    background: none;
+    border: solid 2px #555555;
+    border-radius: 0.35em;
+    width: 100%;
+    max-width: 100%;
+    padding: 0.85em;
+    outline: none;
+}


### PR DESCRIPTION
Added styling for the two textareas and replaced the less than and greater than signs with left and right arrows.

Pull request for issue #20.
