### PR TITLE
Feature/beautify da urls

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,9 +1,9 @@
 <!-- Header -->
 <header id="header" class="skel-layers-fixed">
-  <h1><a href="/index.html">tl;dr<span>{Code}</span></a></h1>
+  <h1><a href="/">tl;dr<span>{Code}</span></a></h1>
   <nav id="nav">
     <ul>
-      <li><a href="/index.html">Home</a></li>
+      <li><a href="/">Home</a></li>
       <li>
         <a href="">Languages <i class="icon fa-angle-down"></i></a>
         <ul>

--- a/_languages/.template.markdown
+++ b/_languages/.template.markdown
@@ -9,6 +9,10 @@ layout: language
 #If you know of other better font icon libraries we should use tell us
 icon: icon-c
 
+# Permalink - the permanent link for this language for a nice looking URL.
+# Should just be language but all lower case - needs trailing /
+permalink: c/
+
 #Basic language details
 Language: C
 Language_Description: General purpose, low-level programming language.

--- a/_languages/c-plusplus.markdown
+++ b/_languages/c-plusplus.markdown
@@ -1,6 +1,7 @@
 ---
 layout: language
 icon: icon-cplusplus
+permalink: c-plusplus/
 
 Language: C++
 Language_Description: Object oriented programming language based on 'C.'

--- a/_languages/c-sharp.markdown
+++ b/_languages/c-sharp.markdown
@@ -1,6 +1,7 @@
 ---
 layout: language
 icon: icon-csharp
+permalink: csharp/
 
 Language: 'C#'
 Language_Description: An object oriented hybrid of C and C++ designed for Windows development.

--- a/_languages/c.markdown
+++ b/_languages/c.markdown
@@ -1,6 +1,7 @@
 ---
 layout: language
 icon: icon-c
+permalink: c/
 
 Language: C
 Language_Description: General purpose, low-level programming language.

--- a/_languages/java.markdown
+++ b/_languages/java.markdown
@@ -1,6 +1,7 @@
 ---
 layout: language
 icon: icon-java
+permalink: java/
 
 Language: Java
 Language_Description: Class based, object oriented programming with few implementation dependencies.

--- a/_languages/javascript.markdown
+++ b/_languages/javascript.markdown
@@ -1,6 +1,7 @@
 ---
 layout: language
 icon: icon-javascript
+permalink: javascript/
 
 Language: JavaScript
 Language_Description: Object oriented programming language mostly used to create interactive effects within web browsers.

--- a/_languages/powershell.markdown
+++ b/_languages/powershell.markdown
@@ -1,6 +1,7 @@
 ---
 layout: language
 icon: icon-shell
+permalink: powershell/
 
 Language: PowerShell
 Language_Description: A task automation and configuration management framework from Microsoft.

--- a/_languages/python.markdown
+++ b/_languages/python.markdown
@@ -1,6 +1,7 @@
 ---
 layout: language
 icon: icon-python
+permalink: python/
 
 Language: Python
 Language_Description: General purpose, high-level programming language.

--- a/_languages/ruby.markdown
+++ b/_languages/ruby.markdown
@@ -1,6 +1,7 @@
 ---
 layout: language
 icon: icon-ruby
+permalink: ruby/
 
 Language: Ruby
 Language_Description: General purpose, object oriented programming language.

--- a/_languages/scala.markdown
+++ b/_languages/scala.markdown
@@ -1,6 +1,8 @@
 ---
 layout: language
 icon: icon-scala
+permalink: scala/
+
 Language: Scala
 Language_Description: An object-functional language that runs on the JVM.
 

--- a/_layouts/language.html
+++ b/_layouts/language.html
@@ -32,7 +32,7 @@ layout: default
 
         {% assign counter = 0 %}
         {% for category in page %}
-          {% if category[0] != "layout" and category[0] != "icon" and category[0] != "Language" and category[0] != "Language_Description" and category[0] != "prism_name" and category[0] != "output" and category[0] != "content" and category[0] != "path" and category[0] != "relative_path" and category[0] != "url" and category[0] != "collection" %}
+          {% if category[0] != "layout" and category[0] != "permalink" and category[0] != "icon" and category[0] != "Language" and category[0] != "Language_Description" and category[0] != "prism_name" and category[0] != "output" and category[0] != "content" and category[0] != "path" and category[0] != "relative_path" and category[0] != "url" and category[0] != "collection" %}
             {% capture modulo %}{{ counter | modulo:3 }}{% endcapture %}
             {% if modulo == '0' or counter == '0' %}
               {% if counter != 0 %}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,7 +4,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for language in site.languages %}
     <url>
-        <loc>http://tldrcode.com{{ language.url | remove: 'index.html' }}</loc>
+        <loc>http://tldrcode.com/{{ language.permalink | remove: 'index.html' }}</loc>
     </url>
     {% endfor %}
 


### PR DESCRIPTION
Home page clicks now go straight to `tldrcode.com/`.

Use the permalink variable in the YAML frontmatter to have nice URLs.

Before and After - 
http://tldrcode.com/languages/python.html
http://tldrcode.com/python/

Works without the trailing slash as well on my local test vagrant.
http://tldrcode.com/python

This **breaks all of the old links.**
