### PR TITLE
Vagrant setup enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ _site/
 .vagrant/
 
 *.swp
+
+Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -30,11 +30,18 @@ If you want to run a local version of the tl;dr{code} with vagrant, install
 [vagrant](https://www.vagrantup.com/) and change to the tldrcode.com project directory. Follow these instructions -
 
     vagrant up
-    vagrant ssh
-    cd /vagrant
-    jekyll server --watch -P 8080 --force_polling
+    # This command is run automatically by the Vagrant provisioner whenever the
+    # machine comes up, no need to do this manually
+    cd /vagrant; jekyll server --watch -P 8080 --force_polling
 
 There is a vagrantfile preconfigured in the project directory.
+
+If you want to run the same `HTML-Proofer` we run for Travis-CI in the vagrant
+box -
+
+    vagrant ssh
+    cd /vagrant
+    htmlproof ./_site --href_ignore "#"
 
 FAQ
 ---

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,11 @@ Vagrant::Config.run do |config|
   config.vm.forward_port 8080, 8080
 
   config.vm.provision :shell,
-    :inline => "sudo apt-get update && sudo apt-get -y install build-essential git ruby1.9.3 && sudo apt-get -y install nodejs ruby-bundler && sudo gem install github-pages --no-ri --no-rdoc"
+    :inline => """sudo apt-get update && sudo apt-get -y install build-essential git ruby1.9.3 && sudo apt-get -y install nodejs ruby-bundler && cd /vagrant && sudo gem install bundler && sudo bundle install"
+
+  config.vm.provision "jekyll", type: "shell",
+    :inline => "cd /vagrant; nohup jekyll server --watch -P 8080 --force_polling > /jekyll.log &",
+    run: "always"
 
   config.ssh.forward_agent = true
 


### PR DESCRIPTION
Using the Gemfile to install the components needed for the installation in the Vagrant file - get as close to the setup that also occurs in Travis-CI.

Add a provision command that will run whenever the machine `vagrant up`'s - the jekyll server will start in the background of the system, you no longer need to do that manually.

Machine also will now have the htmlproof app installed - same thing that is being used for the Travis-CI checks, so you can run the same check that the CI environment does. See instructions in the README.
