### PR TITLE
Vagrantfile mods and add Vagrant-cachier

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,10 @@
-Vagrant::Config.run do |config|
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
 
+Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
-  config.vm.forward_port 8080, 8080
+
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
 
   config.vm.provision :shell,
     :inline => """sudo apt-get update && sudo apt-get -y install build-essential git ruby1.9.3 && sudo apt-get -y install nodejs ruby-bundler && cd /vagrant && sudo gem install bundler && sudo bundle install"
@@ -12,4 +15,10 @@ Vagrant::Config.run do |config|
 
   config.ssh.forward_agent = true
 
+  if Vagrant.has_plugin?("vagrant-cachier")
+    # Configure cached packages to be shared between instances of the same base box.
+    # More info on http://fgrehm.viewdocs.io/vagrant-cachier/usage
+    config.cache.scope = :box
+
+  end
 end


### PR DESCRIPTION
Start of the Vagrantfile was using an odd first statement - was for an
older version of Vagrant not the newest - updated accordingly.

If anyone has the `vagrant-cachier` plugin installed it will end up
using the local cache it sets up to speed up the download time for
packages when the apt-get installs are running. If you don't have it
nothing will happen.
